### PR TITLE
Add flow on templates

### DIFF
--- a/src/client/actions/Message.ts
+++ b/src/client/actions/Message.ts
@@ -229,9 +229,15 @@ export class Message {
 
     // Validate flow if provided
     if (payload.flow) {
-      if (!payload.flow.flow_id) {
+      if (!payload.flow.flow_id && !payload.flow.flow_name) {
         throw new WhatsAppApiException(
-          "Flow ID is required for flow messages",
+          "Flow ID or Flow name is required for flow messages",
+          0
+        );
+      }
+      if (payload.flow.flow_id && payload.flow.flow_name) {
+        throw new WhatsAppApiException(
+          "Cannot use both flow_id and flow_name. Use only one.",
           0
         );
       }
@@ -244,6 +250,12 @@ export class Message {
       if (!payload.flow.body) {
         throw new WhatsAppApiException(
           "Body text is required for flow messages",
+          0
+        );
+      }
+      if (payload.flow.mode && !["draft", "published"].includes(payload.flow.mode)) {
+        throw new WhatsAppApiException(
+          "Flow mode must be 'draft' or 'published'",
           0
         );
       }
@@ -314,7 +326,7 @@ export class Message {
 
       // Validate button sub_type if it's a button
       if (component.type === "button" && component.sub_type) {
-        if (!["quick_reply", "url", "CATALOG"].includes(component.sub_type)) {
+        if (!["quick_reply", "url", "CATALOG", "flow"].includes(component.sub_type)) {
           throw new WhatsAppApiException(
             `Invalid button sub_type: ${component.sub_type}`,
             0
@@ -969,10 +981,12 @@ export class Message {
           parameters: {
             flow_message_version: payload.flow.flow_message_version || "3",
             flow_token: payload.flow.flow_token || "unused",
-            flow_id: payload.flow.flow_id,
+            ...(payload.flow.flow_id ? { flow_id: payload.flow.flow_id } : {}),
+            ...(payload.flow.flow_name ? { flow_name: payload.flow.flow_name } : {}),
             flow_cta: payload.flow.flow_cta,
             ...(payload.flow.flow_action ? { flow_action: payload.flow.flow_action } : {}),
             ...(payload.flow.flow_action_payload ? { flow_action_payload: payload.flow.flow_action_payload } : {}),
+            ...(payload.flow.mode ? { mode: payload.flow.mode } : {}),
           } as any,
         },
       };

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -205,7 +205,8 @@ export interface FlowData {
   header?: string
   body: string
   footer?: string
-  flow_id: string
+  flow_id?: string
+  flow_name?: string
   flow_cta: string
   flow_token?: string
   flow_message_version?: string
@@ -214,6 +215,7 @@ export interface FlowData {
     screen?: string
     data?: Record<string, any>
   }
+  mode?: "draft" | "published"
 }
 
 // Address message data

--- a/tests/client/MessageValidation.test.ts
+++ b/tests/client/MessageValidation.test.ts
@@ -73,7 +73,7 @@ describe('Message Validation Logic', () => {
 
       // Validate button sub_type if it's a button
       if (component.type === 'button' && component.sub_type) {
-        if (!['quick_reply', 'url', 'CATALOG'].includes(component.sub_type)) {
+        if (!['quick_reply', 'url', 'CATALOG', 'flow'].includes(component.sub_type)) {
           throw new MockWhatsAppApiException(`Invalid button sub_type: ${component.sub_type}`, 0);
         }
       }
@@ -269,7 +269,8 @@ describe('Message Validation Logic', () => {
       const validComponents = [
         { type: 'header', parameters: [{ type: 'text', text: 'Hello' }] },
         { type: 'body', parameters: [{ type: 'text', text: 'Message body' }] },
-        { type: 'button', sub_type: 'quick_reply', parameters: [{ type: 'payload', payload: 'btn1' }] }
+        { type: 'button', sub_type: 'quick_reply', parameters: [{ type: 'payload', payload: 'btn1' }] },
+        { type: 'button', sub_type: 'flow', parameters: [{ type: 'action', action: { flow_token: 'token' } }] }
       ];
 
       validComponents.forEach(component => {

--- a/tests/client/NewMessageTypes.test.ts
+++ b/tests/client/NewMessageTypes.test.ts
@@ -26,14 +26,20 @@ class NewMessageTypeValidator {
     if (!payload.flow) {
       throw new MockWhatsAppApiException('flow is required', 0);
     }
-    if (!payload.flow.flow_id) {
-      throw new MockWhatsAppApiException('Flow ID is required for flow messages', 0);
+    if (!payload.flow.flow_id && !payload.flow.flow_name) {
+      throw new MockWhatsAppApiException('Flow ID or Flow name is required for flow messages', 0);
+    }
+    if (payload.flow.flow_id && payload.flow.flow_name) {
+      throw new MockWhatsAppApiException('Cannot use both flow_id and flow_name. Use only one.', 0);
     }
     if (!payload.flow.flow_cta) {
       throw new MockWhatsAppApiException('Flow CTA text is required for flow messages', 0);
     }
     if (!payload.flow.body) {
       throw new MockWhatsAppApiException('Body text is required for flow messages', 0);
+    }
+    if (payload.flow.mode && !['draft', 'published'].includes(payload.flow.mode)) {
+      throw new MockWhatsAppApiException("Flow mode must be 'draft' or 'published'", 0);
     }
   }
 
@@ -111,10 +117,12 @@ class NewMessageTypeValidator {
           parameters: {
             flow_message_version: payload.flow.flow_message_version || '3',
             flow_token: payload.flow.flow_token || 'unused',
-            flow_id: payload.flow.flow_id,
+            ...(payload.flow.flow_id ? { flow_id: payload.flow.flow_id } : {}),
+            ...(payload.flow.flow_name ? { flow_name: payload.flow.flow_name } : {}),
             flow_cta: payload.flow.flow_cta,
             ...(payload.flow.flow_action ? { flow_action: payload.flow.flow_action } : {}),
             ...(payload.flow.flow_action_payload ? { flow_action_payload: payload.flow.flow_action_payload } : {}),
+            ...(payload.flow.mode ? { mode: payload.flow.mode } : {}),
           },
         },
       },
@@ -248,10 +256,28 @@ describe('New Message Types', () => {
         .toThrow('flow is required');
     });
 
-    it('should throw error when flow_id is missing', () => {
+    it('should validate a flow message with flow_name instead of flow_id', () => {
+      const payload = {
+        to: '5491155551234',
+        flow: {
+          body: 'Book your appointment',
+          flow_name: 'appointment_booking_v1',
+          flow_cta: 'Book Now',
+        },
+      };
+      expect(() => validator.validateFlow(payload)).not.toThrow();
+    });
+
+    it('should throw error when both flow_id and flow_name are missing', () => {
       const payload = { flow: { body: 'Test', flow_cta: 'Click' } };
       expect(() => validator.validateFlow(payload))
-        .toThrow('Flow ID is required for flow messages');
+        .toThrow('Flow ID or Flow name is required for flow messages');
+    });
+
+    it('should throw error when both flow_id and flow_name are provided', () => {
+      const payload = { flow: { body: 'Test', flow_id: 'FLOW_123', flow_name: 'my_flow', flow_cta: 'Click' } };
+      expect(() => validator.validateFlow(payload))
+        .toThrow('Cannot use both flow_id and flow_name. Use only one.');
     });
 
     it('should throw error when flow_cta is missing', () => {
@@ -266,6 +292,19 @@ describe('New Message Types', () => {
         .toThrow('Body text is required for flow messages');
     });
 
+    it('should throw error for invalid mode value', () => {
+      const payload = { flow: { body: 'Test', flow_id: 'FLOW_123', flow_cta: 'Click', mode: 'invalid' } };
+      expect(() => validator.validateFlow(payload))
+        .toThrow("Flow mode must be 'draft' or 'published'");
+    });
+
+    it('should accept valid mode values', () => {
+      const draftPayload = { flow: { body: 'Test', flow_id: 'FLOW_123', flow_cta: 'Click', mode: 'draft' } };
+      const publishedPayload = { flow: { body: 'Test', flow_id: 'FLOW_123', flow_cta: 'Click', mode: 'published' } };
+      expect(() => validator.validateFlow(draftPayload)).not.toThrow();
+      expect(() => validator.validateFlow(publishedPayload)).not.toThrow();
+    });
+
     it('should build correct flow body with minimal options', () => {
       const body = validator.buildFlowBody(validFlow);
 
@@ -277,6 +316,43 @@ describe('New Message Types', () => {
       expect(body.interactive.action.parameters.flow_cta).toBe('Book Now');
       expect(body.interactive.action.parameters.flow_message_version).toBe('3');
       expect(body.interactive.action.parameters.flow_token).toBe('unused');
+    });
+
+    it('should build flow body with flow_name instead of flow_id', () => {
+      const payload = {
+        to: '5491155551234',
+        flow: {
+          body: 'Book now',
+          flow_name: 'appointment_booking_v1',
+          flow_cta: 'Book!',
+        },
+      };
+
+      const body = validator.buildFlowBody(payload);
+
+      expect(body.interactive.action.parameters.flow_name).toBe('appointment_booking_v1');
+      expect(body.interactive.action.parameters.flow_id).toBeUndefined();
+    });
+
+    it('should build flow body with mode parameter', () => {
+      const payload = {
+        to: '5491155551234',
+        flow: {
+          body: 'Test draft flow',
+          flow_id: 'FLOW_DRAFT',
+          flow_cta: 'Open',
+          mode: 'draft',
+        },
+      };
+
+      const body = validator.buildFlowBody(payload);
+
+      expect(body.interactive.action.parameters.mode).toBe('draft');
+    });
+
+    it('should not include mode when not provided', () => {
+      const body = validator.buildFlowBody(validFlow);
+      expect(body.interactive.action.parameters.mode).toBeUndefined();
     });
 
     it('should build flow body with header and footer', () => {


### PR DESCRIPTION
This pull request adds support for using either a `flow_id` or a `flow_name` (but not both) when sending flow messages, introduces a new optional `mode` parameter for flows (with validation for allowed values), and updates the validation and construction logic throughout the codebase and tests accordingly. It also allows `flow` as a valid button sub_type.

**Flow message enhancements:**

* Updated the `FlowData` interface in `message.ts` to allow either `flow_id` or `flow_name` (both optional, but one required), and added an optional `mode` property restricted to `"draft"` or `"published"` [[1]](diffhunk://#diff-151c362c8c0a9508b3f0d791dae68560c471d38777ba1fcc7c29b2c23b1645e8L208-R209) [[2]](diffhunk://#diff-151c362c8c0a9508b3f0d791dae68560c471d38777ba1fcc7c29b2c23b1645e8R218).
* In `Message.ts`, validation now requires either `flow_id` or `flow_name` (but not both), and checks that `mode` (if provided) is valid. The message construction logic now includes `flow_name` and `mode` in the payload if present [[1]](diffhunk://#diff-d5ce574476097930efbf2d74b15b78e5b30616235c7ae2abb27d6ad8fa79caafL232-R240) [[2]](diffhunk://#diff-d5ce574476097930efbf2d74b15b78e5b30616235c7ae2abb27d6ad8fa79caafR256-R261) [[3]](diffhunk://#diff-d5ce574476097930efbf2d74b15b78e5b30616235c7ae2abb27d6ad8fa79caafL972-R989).

**Button and component validation:**

* Allowed `"flow"` as a valid `sub_type` for button components in both implementation and tests [[1]](diffhunk://#diff-d5ce574476097930efbf2d74b15b78e5b30616235c7ae2abb27d6ad8fa79caafL317-R329) [[2]](diffhunk://#diff-286d43188c0f351e8daae1dc8428a2ca763a9a859e6eb59be4bf9047c4cb9ab3L76-R76) [[3]](diffhunk://#diff-286d43188c0f351e8daae1dc8428a2ca763a9a859e6eb59be4bf9047c4cb9ab3L272-R273).

**Test updates and coverage:**

* Updated and expanded tests in `NewMessageTypes.test.ts` to cover all new validation logic, including cases for missing or conflicting `flow_id`/`flow_name`, invalid and valid `mode` values, and correct construction of message bodies with new parameters [[1]](diffhunk://#diff-49de067360dccb3eb5d09de920e3e55176f17859dffb5696c71f36cac59e314bL29-R43) [[2]](diffhunk://#diff-49de067360dccb3eb5d09de920e3e55176f17859dffb5696c71f36cac59e314bL114-R125) [[3]](diffhunk://#diff-49de067360dccb3eb5d09de920e3e55176f17859dffb5696c71f36cac59e314bL251-R280) [[4]](diffhunk://#diff-49de067360dccb3eb5d09de920e3e55176f17859dffb5696c71f36cac59e314bR295-R307) [[5]](diffhunk://#diff-49de067360dccb3eb5d09de920e3e55176f17859dffb5696c71f36cac59e314bR321-R357).